### PR TITLE
API to set buffers for upstream connect response.

### DIFF
--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -327,6 +327,8 @@ public:
 
   HTTPHdr *getUpstreamConnectRequest();
 
+  void setUpstreamConnectResponseHeadersBuffer(HdrHeapSDKHandle *buffers, HTTPHdr *headers);
+
 private:
   SSLNetVConnection(const SSLNetVConnection &);
   SSLNetVConnection &operator=(const SSLNetVConnection &);
@@ -340,7 +342,6 @@ private:
   int handleUpstreamConnect();
   int sendUpstreamConnect();
   int readUpstreamConnectResponse();
-  void freeUpstreamConnectResponse();
   void freeUpstreamConnectRequest();
 
   bool connectReceived;
@@ -386,7 +387,8 @@ private:
   HdrHeapSDKHandle *upstreamConnectRequestHdrHeap = nullptr;
   HTTPHdr upstreamConnectRequest;
   HdrHeapSDKHandle *upstreamConnectResponseHdrHeap = nullptr;
-  HTTPHdr upstreamConnectResponse;
+  HTTPHdr *upstreamConnectResponse;
+  bool upstreamConnectResponseReadStarted = false;
 
   bool sentUpstreamConnect = false;
   bool upstreamConnectResponseRead = false;

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -9658,3 +9658,33 @@ void TSHttpTxnSetParentAsOrigin(TSHttpTxn txnp)
 	sm->t_state.api_info.parent_is_origin = true;
 }
 
+void *TSVConnOutgoingConnectResponseBufferSet(TSVConn vconn, TSMBuffer *buffer, TSMLoc *loc)
+{
+    sdk_assert(sdk_sanity_check_iocore_structure(vconn) == TS_SUCCESS);
+
+    *buffer = TSMBufferCreate();
+
+    sdk_assert(sdk_sanity_check_mbuffer(*buffer) == TS_SUCCESS);
+
+    NetVConnection *vc = reinterpret_cast<NetVConnection *>(vconn);
+    SSLNetVConnection *ssl_vc = dynamic_cast<SSLNetVConnection *>(vc);
+
+    HdrHeapSDKHandle * hdr = reinterpret_cast<HdrHeapSDKHandle *>(*buffer);
+
+    HTTPHdr *header = new HTTPHdr;
+    header->m_heap = hdr->m_heap;
+    header->create(HTTP_TYPE_RESPONSE);
+    *loc = reinterpret_cast<TSMLoc>(header->m_http);
+    ssl_vc->setUpstreamConnectResponseHeadersBuffer(hdr, header);
+    return header;
+}
+
+void TSOutgoingConnectResponseDestroy(TSMBuffer buffer, TSMLoc loc, void *header)
+{
+    sdk_assert(sdk_sanity_check_mbuffer(buffer) == TS_SUCCESS);
+
+    TSHandleMLocRelease(buffer, TS_NULL_MLOC, loc);
+    TSMBufferDestroy(buffer);
+    HTTPHdr *httpHeader = reinterpret_cast<HTTPHdr*>(header);
+    delete httpHeader;
+}

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -2459,6 +2459,8 @@ tsapi TSReturnCode TSVConnUpstreamConnectGet(TSVConn vconn, TSMBuffer *bufp, TSM
 
 tsapi void TSHttpTxnSetParentAsOrigin(TSHttpTxn txnp);
 
+tsapi void *TSVConnOutgoingConnectResponseBufferSet(TSVConn vconn, TSMBuffer *buffer, TSMLoc *loc);
+tsapi void TSOutgoingConnectResponseDestroy(TSMBuffer buffer, TSMLoc loc, void *header);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Buffers for the response to an upstream connect must be provided by an
external source (e.g., a plugin).